### PR TITLE
Add entrypoint.sh, mount in PyTorch model at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ model/
 gmm_test/
 src/CLEAN/__pycache__/
 .DS_STORE
+
+# Ignore large models that have been fetched manually
+*.pt
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 COPY app /app
 
-RUN pip install --upgrade -r requirements.txt
+RUN pip3 install --upgrade -r requirements.txt
 
 # Ubuntu installation of Pytorch
 RUN pip3 install torch --extra-index-url https://download.pytorch.org/whl/cpu
@@ -16,7 +16,7 @@ RUN mkdir data/esm_data
 RUN mkdir data/pretrained
 
 # Download weights in data/pretrained
-RUN pip install gdown
+RUN pip3 install gdown
 RUN gdown --id 1zrEU-HPNV3wp7wLAx4KnuiVyD794Oboj
 RUN apt-get update && apt-get install -y unzip
 RUN unzip CLEAN_pretrained.zip -d data/pretrained
@@ -26,3 +26,5 @@ RUN python build.py install
 # Initialize the large weights
 # RUN python CLEAN_infer_fasta.py --fasta_data price
 
+COPY entrypoint.sh ./entrypoint.sh
+CMD ["./entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python CLEAN_infer_fasta.py --fasta_data init


### PR DESCRIPTION
## Problem
The Docker image requires a very large file to run: `esm1b_t33_650M_UR50S.pt`

Building this into the Docker image is not advised, as this makes the resulting image very large.
We also saw performance issues trying to build an image this large

## Approach
* Download this file on the host before running the Docker image, not during the build
* Add an `entrypoint.sh`, which will execute after the container start up
* In production, we can mount this as read-only shared data to each job by creating a PVC backed by NFS

## How to Test
1. Checkout and run this branch locally
2. Rebuild the Docker image: `docker build -t moleculemaker/test-clean .`
3. Download the PyTorch model - **WARNING: 7.3GB file download**
    * https://dl.fbaipublicfiles.com/fair-esm/models/esm1b_t33_650M_UR50S.pt

**Interactive Mode (dev)**
This can be used to run the steps iteratively, when debugging and developing

Run the Docker image, pass `-it` flag and `bash` as the command to run, and mount the downloaded file using `-v`:
```bash
% docker run -it --rm -v $(pwd)/esm1b_t33_650M_UR50S.pt:/root/.cache/torch/hub/checkpoints/esm1b_t33_650M_UR50S.pt moleculemaker/test-clean bash

root@975c4ccd2a54:/app# python CLEAN_infer_fasta.py --fasta_data init
Downloading: "https://dl.fbaipublicfiles.com/fair-esm/regression/esm1b_t33_650M_UR50S-contact-regression.pt" to /root/.cache/torch/hub/checkpoints/esm1b_t33_650M_UR50S-contact-regression.pt
Read data/init.fasta with 1 sequences
Processing 1 of 1 batches (1 sequences)
The embedding sizes for train and test: torch.Size([241025, 128]) torch.Size([1, 128])
100%|███████████████████████████████████████████████████████████████████████████████████████████████| 5242/5242 [00:00<00:00, 41695.51it/s]
Calculating eval distance map, between 1 test ids and 5242 train EC cluster centers
1it [00:00, 194.64it/s]

root@975c4ccd2a54:/app#
```

**Batch Mode (prod)**
This is the how the Docker image will run in production
We will make the `esm1b_t33_650M_UR50S.pt` available over read-only NFS in the cluster, so it will be there at runtime

Run the Docker image using the default command, and mount the downloaded file using `-v`:
```bash
% docker run --rm -v $(pwd)/esm1b_t33_650M_UR50S.pt:/root/.cache/torch/hub/checkpoints/esm1b_t33_650M_UR50S.pt moleculemaker/test-cleanDownloading: "https://dl.fbaipublicfiles.com/fair-esm/regression/esm1b_t33_650M_UR50S-contact-regression.pt" to /root/.cache/torch/hub/checkpoints/esm1b_t33_650M_UR50S-contact-regression.pt
Read data/init.fasta with 1 sequences
Processing 1 of 1 batches (1 sequences)
The embedding sizes for train and test: torch.Size([241025, 128]) torch.Size([1, 128])
100%|███████████████████████████████████████████████████████████████████████████████████████████████| 5242/5242 [00:00<00:00, 44668.21it/s]
Calculating eval distance map, between 1 test ids and 5242 train EC cluster centers
1it [00:00, 151.33it/s]
```

#### Docker Appendix
Short explanation of the above arguments for `docker run`:
* `--rm` - immediately remove the container after it stops
* `-it` - attach with an interactive shell (tty)
* `-v` - mount a file into the container at runtime