### PR TITLE
add `-y` in quickstart for automatic installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Manuscript result was obtained using Python 3.10.4; PyTorch 1.11.0; CUDA 11.3; f
 ```
 
 cd CLEAN/app/
-conda create -n clean python==3.10.4
+conda create -n clean python==3.10.4 -y
 conda activate clean
 pip install -r requirements.txt
 


### PR DESCRIPTION
When starting quick-installing, copying all command in clipboard and pasting them may cause inconvenience, for there's not default **agree** for installation.

Here, I propose a `-y` command to fix this problem.

Please check it and merge it to main branch!

Thank you for checking this!